### PR TITLE
Add priority prop for logos

### DIFF
--- a/src/components/ui/jumbotron.tsx
+++ b/src/components/ui/jumbotron.tsx
@@ -43,6 +43,7 @@ const Jumbotron: React.FC<JumbotronProps> = ({
             layout="fill"
             objectFit="cover"
             objectPosition="center"
+            priority
           />
         </Link>
         <h1 className="text-5xl font-bold leading-none tracking-tight text-[#2B161B] transition-all dark:text-gray-100 md:text-5xl lg:text-6xl">

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -35,6 +35,7 @@ const Navbar: React.FC = () => {
               layout="fill"
               objectFit="cover"
               objectPosition="center"
+              priority
             />
           </Link>
         </div>


### PR DESCRIPTION
Add the `priority` prop to prioritize logos and preload them. Should be a noticeable boost in LCP.