### PR TITLE
fix: correct dates and add mobile swipe navigation

### DIFF
--- a/src/components/timetable/Timetable.tsx
+++ b/src/components/timetable/Timetable.tsx
@@ -4,7 +4,7 @@ import { SHORT_HOURS } from "@/constants/settings";
 import { adjustShortenedLessons } from "@/lib/adjustShortenedLessons";
 import { useSettingsStore, useSettingsWithoutStore } from "@/stores/settings";
 import { OptivumTimetable } from "@/types/optivum";
-import { FC, useMemo } from "react";
+import { FC, useMemo, useRef } from "react";
 import {
   ShortLessonSwitcherCell,
   TableHeaderCell,
@@ -57,8 +57,29 @@ export const Timetable: FC<TimetableProps> = ({ timetable }) => {
     }
   };
 
+  const touchStartX = useRef<number | null>(null);
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+  };
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    if (touchStartX.current === null) return;
+    const diff = e.changedTouches[0].clientX - touchStartX.current;
+    if (Math.abs(diff) > 50) {
+      const increment = diff < 0 ? 1 : -1;
+      const totalDays = timetable.dayNames.length;
+      const nextIndex =
+        (selectedDayIndex + increment + totalDays) % totalDays;
+      handleDayChange(nextIndex);
+    }
+    touchStartX.current = null;
+  };
+
   return (
-    <div className="h-fit w-full border-lines bg-foreground transition-all max-md:mb-20 md:overflow-hidden md:rounded-md md:border">
+    <div
+      className="h-fit w-full border-lines bg-foreground transition-all max-md:mb-20 md:overflow-hidden md:rounded-md md:border"
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+    >
       <div className="sticky top-0 z-20 flex justify-between divide-x divide-lines border-y border-lines bg-foreground md:hidden">
         {timetable.dayNames.map((dayName) => (
           <TableHeaderMobileCell

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -33,33 +33,27 @@ export const getDayNumberForNextWeek = (
   monthNumber: number;
 } => {
   const today = new Date();
-  const todayDayOfWeek = today.getDay();
+  // JavaScript's getDay is 0 for Sunday, but our DAYS_OF_WEEK starts from Monday (index 0)
+  const todayIndex = (today.getDay() + 6) % 7;
+
   const targetDay = DAYS_OF_WEEK.find(
     (day) => day.long === dayName || day.short === dayName,
   );
 
   if (!targetDay) {
     console.error("Day not found");
-
     return {
       dayNumber: today.getDate(),
-      month: moment(today.getMonth() + 1).format("MMM"),
+      month: moment(today).format("MMM"),
       monthNumber: today.getMonth() + 1,
     };
   }
 
-  const targetDayOfWeek = targetDay.index + 1;
-
-  const daysUntilTarget = (targetDayOfWeek - todayDayOfWeek + 7) % 7;
+  let diff = targetDay.index - todayIndex;
+  if (diff < 0) diff += 7; // always choose a future date
 
   const targetDate = new Date(today);
-  targetDate.setDate(today.getDate() + daysUntilTarget);
-
-  if (daysUntilTarget === 0 && todayDayOfWeek === targetDayOfWeek) {
-    targetDate.setDate(today.getDate());
-  } else if (targetDayOfWeek < todayDayOfWeek) {
-    targetDate.setDate(today.getDate() - (todayDayOfWeek - targetDayOfWeek));
-  }
+  targetDate.setDate(today.getDate() + diff);
 
   return {
     dayNumber: targetDate.getDate(),


### PR DESCRIPTION
## Summary
- ensure `getDayNumberForNextWeek` always returns the upcoming date
- allow mobile users to switch timetable days with swipe gestures

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c73a4b33b0832399dd436240322879