### PR TITLE
Show countdown only for current day on mobile

### DIFF
--- a/src/components/timetable/Cells.tsx
+++ b/src/components/timetable/Cells.tsx
@@ -11,9 +11,13 @@ import { useIsClient } from "usehooks-ts";
 
 interface TableHourCellProps {
   hour: TableHour;
+  isCurrentDay?: boolean;
 }
 
-export const TableHourCell: FC<TableHourCellProps> = ({ hour }) => {
+export const TableHourCell: FC<TableHourCellProps> = ({
+  hour,
+  isCurrentDay = true,
+}) => {
   const isClient = useIsClient();
   const [currentTime, setCurrentTime] = useState(() => {
     const now = new Date();
@@ -34,7 +38,8 @@ export const TableHourCell: FC<TableHourCellProps> = ({ hour }) => {
   const start = useMemo(() => parseTime(hour.timeFrom), [hour.timeFrom]);
   const end = useMemo(() => parseTime(hour.timeTo), [hour.timeTo]);
   const isCurrent = currentTime >= start && currentTime < end;
-  const timeRemaining = isCurrent ? end - currentTime : 0;
+  const shouldShow = isCurrent && isCurrentDay;
+  const timeRemaining = shouldShow ? end - currentTime : 0;
 
   const { minutesRemaining, secondsRemaining } = useMemo(() => {
     const minutes = Math.floor(timeRemaining / 60)
@@ -46,7 +51,7 @@ export const TableHourCell: FC<TableHourCellProps> = ({ hour }) => {
 
   return (
     <td className="relative px-4 py-3 text-center max-md:w-32">
-      {isCurrent && isClient && (
+      {shouldShow && isClient && (
         <div className="absolute left-0 h-[calc(100%-1.5rem)] w-1 rounded-r-lg bg-accent-table"></div>
       )}
       <h2 className="text-lg font-semibold text-primary/90 sm:text-xl">
@@ -57,7 +62,7 @@ export const TableHourCell: FC<TableHourCellProps> = ({ hour }) => {
           <p className="text-xs font-medium text-primary/70 sm:text-sm">
             {hour.timeFrom}-{hour.timeTo}
           </p>
-          {isCurrent && (
+          {shouldShow && (
             <p className="mx-auto rounded-sm border border-accent-table bg-accent-table px-2 py-0.5 text-center text-sm font-medium text-accent/90 dark:bg-accent-table/10 dark:text-primary/90">
               {`${minutesRemaining}:${secondsRemaining}`}
             </p>

--- a/src/components/timetable/Timetable.tsx
+++ b/src/components/timetable/Timetable.tsx
@@ -51,6 +51,8 @@ export const Timetable: FC<TimetableProps> = ({ timetable }) => {
     [timetable.lessons],
   );
 
+  const todayIndex = useMemo(() => (new Date().getDay() + 6) % 7, []);
+
   const handleDayChange = (newIndex: number) => {
     if (selectedDayIndex !== newIndex) {
       setSelectedDayIndex(newIndex);
@@ -108,7 +110,10 @@ export const Timetable: FC<TimetableProps> = ({ timetable }) => {
                         key={hourIndex}
                         className="border-b border-lines odd:bg-accent/50 odd:dark:bg-background"
                       >
-                        <TableHourCell hour={hour} />
+                        <TableHourCell
+                          hour={hour}
+                          isCurrentDay={dayIndex === todayIndex}
+                        />
                         <td className="py-3 last:border-0 max-md:px-2 md:px-4">
                           {(timetable.lessons?.[dayIndex]?.[hourIndex] ?? []).map(
                             (lessonItem, index) => (


### PR DESCRIPTION
## Summary
- add optional `isCurrentDay` prop to `TableHourCell` and restrict countdown display to that day
- compute current day index and pass it on mobile timetable rendering

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7be311a608323bdc9403ab62193ca