### PR TITLE
fix: correct dates, add swipe animation, refine UI copy, and clean up types

### DIFF
--- a/src/components/common/BottomBar.tsx
+++ b/src/components/common/BottomBar.tsx
@@ -93,8 +93,8 @@ export const BottomBar: FC<TopbarProps> = ({ timetable }) => {
         <VisuallyHidden>
           <DrawerTitle>Przeglądaj plan zajęć</DrawerTitle>
           <DrawerDescription>
-            Lorem ipsum dolor sit amet consectetur, adipisicing elit. Saepe,
-            sapiente.
+            Wybierz klasę, nauczyciela lub salę, aby zobaczyć odpowiedni plan
+            zajęć.
           </DrawerDescription>
         </VisuallyHidden>
         <div className="flex h-full flex-col justify-between gap-y-16">

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -155,8 +155,8 @@ export const SettingsPanel = () => {
             <SheetTitle>Dodatkowe funkcje</SheetTitle>
             <VisuallyHidden>
               <SheetDescription>
-                Lorem ipsum dolor sit amet consectetur, adipisicing elit. Saepe,
-                sapiente.
+                Panel z dodatkowymi funkcjami planu — umożliwia wyszukiwanie sal
+                i zmianę ustawień.
               </SheetDescription>
             </VisuallyHidden>
             <Button

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -52,8 +52,7 @@ export const Sidebar: FC = () => {
             <SidebarContent />
             <VisuallyHidden>
               <SheetDescription>
-                Lorem ipsum dolor sit amet consectetur, adipisicing elit. Saepe,
-                sapiente.
+                Lista wszystkich klas, nauczycieli i sal dostępnych w planie.
               </SheetDescription>
             </VisuallyHidden>
           </SheetContent>

--- a/src/components/timetable/Timetable.tsx
+++ b/src/components/timetable/Timetable.tsx
@@ -4,14 +4,14 @@ import { SHORT_HOURS } from "@/constants/settings";
 import { adjustShortenedLessons } from "@/lib/adjustShortenedLessons";
 import { useSettingsStore, useSettingsWithoutStore } from "@/stores/settings";
 import { OptivumTimetable } from "@/types/optivum";
-import { FC, useMemo } from "react";
+import { FC, useMemo, useRef, useState } from "react";
 import {
   ShortLessonSwitcherCell,
   TableHeaderCell,
   TableHeaderMobileCell,
   TableHourCell,
 } from "./Cells";
-import { TableLessonCell } from "./LessonCells";
+import { LessonItem, TableLessonCell } from "./LessonCells";
 
 interface TimetableProps {
   timetable: OptivumTimetable;
@@ -51,11 +51,76 @@ export const Timetable: FC<TimetableProps> = ({ timetable }) => {
     [timetable.lessons],
   );
 
-  const handleDayChange = (newIndex: number) => {
+  const totalDays = timetable.dayNames.length;
+
+  const [animIndex, setAnimIndex] = useState(selectedDayIndex + 1);
+  const [isAnimating, setIsAnimating] = useState(false);
+
+  const handleDaySelect = (newIndex: number) => {
     if (selectedDayIndex !== newIndex) {
       setSelectedDayIndex(newIndex);
+      setAnimIndex(newIndex + 1);
     }
   };
+
+  const moveDay = (increment: number) => {
+    const nextIndex = (selectedDayIndex + increment + totalDays) % totalDays;
+    setSelectedDayIndex(nextIndex);
+    setIsAnimating(true);
+    if (selectedDayIndex === 0 && increment === -1) {
+      setAnimIndex(0);
+    } else if (selectedDayIndex === totalDays - 1 && increment === 1) {
+      setAnimIndex(totalDays + 1);
+    } else {
+      setAnimIndex((prev) => prev + increment);
+    }
+  };
+
+  const handleTransitionEnd = () => {
+    setIsAnimating(false);
+    if (animIndex === 0) {
+      setAnimIndex(totalDays);
+    } else if (animIndex === totalDays + 1) {
+      setAnimIndex(1);
+    }
+  };
+
+  const touchStartX = useRef<number | null>(null);
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+  };
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    if (touchStartX.current === null) return;
+    const diff = e.changedTouches[0].clientX - touchStartX.current;
+    if (Math.abs(diff) > 50) {
+      moveDay(diff < 0 ? 1 : -1);
+    }
+    touchStartX.current = null;
+  };
+
+  const renderDay = (dayIndex: number, key: React.Key) => (
+    <table key={key} className="w-full flex-shrink-0">
+      <tbody>
+        {Object.values(hours)
+          .slice(0, maxLessons)
+          .map((hour, hourIndex) => (
+            <tr
+              key={hourIndex}
+              className="border-b border-lines odd:bg-accent/50 odd:dark:bg-background"
+            >
+              <TableHourCell hour={hour} />
+              <td className="py-3 last:border-0 max-md:px-2 md:px-4">
+                {(timetable.lessons?.[dayIndex]?.[hourIndex] ?? []).map(
+                  (lessonItem, index) => (
+                    <LessonItem key={index} lesson={lessonItem} />
+                  ),
+                )}
+              </td>
+            </tr>
+          ))}
+      </tbody>
+    </table>
+  );
 
   return (
     <div className="h-fit w-full border-lines bg-foreground transition-all max-md:mb-20 md:overflow-hidden md:rounded-md md:border">
@@ -65,12 +130,36 @@ export const Timetable: FC<TimetableProps> = ({ timetable }) => {
             key={dayName}
             dayName={dayName}
             selectedDayIndex={selectedDayIndex}
-            setSelectedDayIndex={handleDayChange}
+            setSelectedDayIndex={handleDaySelect}
           />
         ))}
       </div>
 
-      <div className="h-full w-full md:overflow-auto">
+      {/* Mobile timetable with sliding animation */}
+      {hasLessons && (
+        <div
+          className="md:hidden overflow-hidden"
+          onTouchStart={handleTouchStart}
+          onTouchEnd={handleTouchEnd}
+        >
+          <div
+            className={`flex w-full ${
+              isAnimating ? "transition-transform duration-300" : ""
+            }`}
+            style={{ transform: `translateX(-${animIndex * 100}%)` }}
+            onTransitionEnd={handleTransitionEnd}
+          >
+            {renderDay(totalDays - 1, "clone-last")}
+            {timetable.dayNames.map((_, dayIndex) =>
+              renderDay(dayIndex, dayIndex),
+            )}
+            {renderDay(0, "clone-first")}
+          </div>
+        </div>
+      )}
+
+      {/* Desktop timetable */}
+      <div className="h-full w-full max-md:hidden md:overflow-auto">
         {hasLessons && (
           <table className="w-full">
             <thead className="max-md:hidden">

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -33,33 +33,27 @@ export const getDayNumberForNextWeek = (
   monthNumber: number;
 } => {
   const today = new Date();
-  const todayDayOfWeek = today.getDay();
+  // JavaScript's getDay is 0 for Sunday, but our DAYS_OF_WEEK starts from Monday (index 0)
+  const todayIndex = (today.getDay() + 6) % 7;
+
   const targetDay = DAYS_OF_WEEK.find(
     (day) => day.long === dayName || day.short === dayName,
   );
 
   if (!targetDay) {
     console.error("Day not found");
-
     return {
       dayNumber: today.getDate(),
-      month: moment(today.getMonth() + 1).format("MMM"),
+      month: moment(today).format("MMM"),
       monthNumber: today.getMonth() + 1,
     };
   }
 
-  const targetDayOfWeek = targetDay.index + 1;
-
-  const daysUntilTarget = (targetDayOfWeek - todayDayOfWeek + 7) % 7;
+  let diff = targetDay.index - todayIndex;
+  if (diff < 0) diff += 7; // always choose a future date
 
   const targetDate = new Date(today);
-  targetDate.setDate(today.getDate() + daysUntilTarget);
-
-  if (daysUntilTarget === 0 && todayDayOfWeek === targetDayOfWeek) {
-    targetDate.setDate(today.getDate());
-  } else if (targetDayOfWeek < todayDayOfWeek) {
-    targetDate.setDate(today.getDate() - (todayDayOfWeek - targetDayOfWeek));
-  }
+  targetDate.setDate(today.getDate() + diff);
 
   return {
     dayNumber: targetDate.getDate(),


### PR DESCRIPTION
## Summary
- ensure `getDayNumberForNextWeek` always returns the upcoming date
- allow mobile users to switch timetable days with animated swipe gestures
- replace placeholder descriptions in settings, sidebar, and bottom bar for clearer UI text
- remove unused image type declarations
- wrap timetable swipes so moving past Monday or Friday animates only a single step

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm build` *(fails: Failed to fetch Optivum list - connect ENETUNREACH 89.161.150.43:80)*


------
https://chatgpt.com/codex/tasks/task_e_68c73a4b33b0832399dd436240322879