### PR TITLE
feat: show empty day message on mobile

### DIFF
--- a/src/components/timetable/Timetable.tsx
+++ b/src/components/timetable/Timetable.tsx
@@ -152,7 +152,7 @@ export const Timetable: FC<TimetableProps> = ({ timetable }) => {
 
       {/* Desktop timetable */}
       <div className="h-full w-full max-md:hidden md:overflow-auto">
-        {hasLessons && (
+        {hasLessons ? (
           <table className="w-full">
             <thead className="max-md:hidden">
               <tr className="divide-x divide-lines border-b border-lines">
@@ -186,6 +186,12 @@ export const Timetable: FC<TimetableProps> = ({ timetable }) => {
                 ))}
             </tbody>
           </table>
+        ) : (
+          <div className="flex h-full w-full flex-col items-center justify-center gap-2 p-4 text-center text-muted-foreground">
+            <CalendarX2 className="h-10 w-10 text-primary/70 dark:text-primary/80" />
+            <h2 className="text-lg font-semibold">Brak planu zajęć</h2>
+            <p className="text-sm">Na ten tydzień nie wprowadzono planu zajęć</p>
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- display centered message when a day has no schedule on mobile
- expand mobile timetable area for easier swiping across days

## Testing
- `pnpm lint`
- `pnpm build` *(fails to fetch Optivum list during build, but build completes)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d4bd4c6083238840b0aa3bcf255a