### PR TITLE
feat: parse and show timetable dates

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-toast": "^1.2.4",
     "@radix-ui/react-visually-hidden": "^1.1.1",
     "@sentry/nextjs": "^8.50.0",
+    "any-date-parser": "^2.2.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cookies-next": "^4.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@sentry/nextjs':
         specifier: ^8.50.0
         version: 8.50.0(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.56.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.1.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(webpack@5.95.0)
+      any-date-parser:
+        specifier: ^2.2.3
+        version: 2.2.3
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1237,6 +1240,9 @@ packages:
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
+
+  any-date-parser@2.2.3:
+    resolution: {integrity: sha512-PNWQcq4V6Ag52BElutsdg3hQT9v6R604/jdpL/hSCKHDuB6qNaXVFEqLOg8ANwKgte0dSVMTc4Z3Zy9YFv1oSQ==}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -4442,6 +4448,8 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@6.2.1: {}
+
+  any-date-parser@2.2.3: {}
 
   any-promise@1.3.0: {}
 

--- a/src/actions/getOptivumTimetable.ts
+++ b/src/actions/getOptivumTimetable.ts
@@ -6,6 +6,7 @@ import { OptivumTimetable } from "@/types/optivum";
 import { Table } from "@majusss/timetable-parser";
 import moment from "moment";
 import "moment/locale/pl";
+import parser from "any-date-parser";
 import { getOptivumList } from "./getOptivumList";
 
 export const getOptivumTimetable = async (
@@ -33,16 +34,28 @@ export const getOptivumTimetable = async (
     const data = await res.text();
     const timeTableData = new Table(data);
 
+    const generatedRaw = timeTableData.getGeneratedDate() ?? "";
+    const generatedParsed = parser.fromString(generatedRaw, "pl");
+    const generatedDate = generatedParsed.isValid()
+      ? moment(generatedParsed)
+          .locale("pl")
+          .format("D MMMM YYYY[r.]")
+      : null;
+
+    const validRaw = timeTableData.getVersionInfo();
+    const validParsed = parser.fromString(validRaw, "pl");
+    const validDate = validParsed.isValid()
+      ? moment(validParsed).locale("pl").format("D MMMM YYYY[r.]")
+      : null;
+
     return {
       id,
       hours: timeTableData.getHours(),
       lessons: timeTableData.getDays(),
-      generatedDate: moment(timeTableData.getGeneratedDate())
-        .locale("pl")
-        .format("DD MMMM YYYY[r.]"),
+      generatedDate,
       title: timeTableData.getTitle(),
       type: type as OptivumTimetable["type"],
-      validDate: timeTableData.getVersionInfo(),
+      validDate,
       dayNames: timeTableData.getDayNames(),
       list: await getOptivumList(),
       lastUpdated: parseHeaderDate(res),

--- a/src/components/topbar/Topbar.tsx
+++ b/src/components/topbar/Topbar.tsx
@@ -44,6 +44,9 @@ export const Topbar: FC<TopbarProps> = ({ timetable }) => {
         </div>
         <TopbarButtons />
       </div>
+      <div className="md:hidden">
+        <Dates timetable={timetable} />
+      </div>
       <div className="grid gap-1.5 max-md:hidden">
         <div className="inline-flex items-center gap-x-4">
           <h1 className="max-w-2xl truncate text-ellipsis text-3xl font-semibold leading-tight text-primary/90 xl:text-4.2xl">

--- a/src/types/optivum.d.ts
+++ b/src/types/optivum.d.ts
@@ -19,7 +19,7 @@ interface OptivumTimetable {
   generatedDate: string | null;
   title: string;
   type: "class" | "teacher" | "room";
-  validDate: string;
+  validDate: string | null;
   dayNames: string[];
   list: List;
   lastUpdated: string;


### PR DESCRIPTION
## Summary
- parse timetable generation and validity dates with any-date-parser
- display generation and validity info in mobile topbar
- allow nullable timetable validity date

## Testing
- `pnpm lint`
- `CI=1 pnpm build` *(fails: connect ENETUNREACH 89.161.150.43:80)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e4aa926c8323b5265e2643791505