### PR TITLE
Add banner for alternate data sources

### DIFF
--- a/src/app/[...path]/page.tsx
+++ b/src/app/[...path]/page.tsx
@@ -1,6 +1,7 @@
 import { getOptivumList } from "@/actions/getOptivumList";
 import { getOptivumTimetable } from "@/actions/getOptivumTimetable";
 import { BottomBar } from "@/components/common/BottomBar";
+import { DataSourceBanner } from "@/components/common/DataSourceBanner";
 import { FreeRoomsResultModal } from "@/components/modals/FreeRoomsResult";
 import { FreeRoomsSearchModal } from "@/components/modals/FreeRoomsSearch";
 import { ShortenedLessonsCalculatorModal } from "@/components/modals/ShortenedLessonsCalculator";
@@ -71,6 +72,7 @@ const TimetablePage = async ({
     <Fragment>
       <TimetableController timetable={timetable} />
       <div className="flex h-full w-full flex-col gap-y-3 max-md:overflow-y-auto md:gap-y-6 md:overflow-hidden md:p-8">
+        <DataSourceBanner />
         <Topbar timetable={timetable} />
         <Timetable timetable={timetable} />
         <BottomBar timetable={timetable} />

--- a/src/components/common/DataSourceBanner.tsx
+++ b/src/components/common/DataSourceBanner.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { prettyNameFromUrl, isOriginalDataSource } from "@/lib/dataSource";
+import { cn } from "@/lib/utils";
+import { useDataSourceStore } from "@/stores/dataSource";
+import { AlertTriangle } from "lucide-react";
+import { useMemo } from "react";
+
+export const DataSourceBanner = () => {
+  const { selectedDataSource, availableDataSources } = useDataSourceStore();
+
+  const isOriginalSource = isOriginalDataSource(selectedDataSource);
+
+  const selectedSourceName = useMemo(() => {
+    if (!selectedDataSource) return null;
+
+    const matchingSource = availableDataSources.find(
+      (source) => source.url === selectedDataSource,
+    );
+
+    if (matchingSource) {
+      return matchingSource.name;
+    }
+
+    return prettyNameFromUrl(selectedDataSource);
+  }, [availableDataSources, selectedDataSource]);
+
+  if (!selectedDataSource || isOriginalSource) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        "w-full rounded-xl border border-primary/10 bg-primary/5 px-4 py-3 shadow-sm",
+        "text-primary/80",
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <div className="grid h-10 w-10 place-items-center rounded-full bg-primary/10 text-primary/70">
+          <AlertTriangle className="h-5 w-5" strokeWidth={2.5} />
+        </div>
+        <div className="grid gap-1 text-sm leading-relaxed">
+          <p className="font-semibold text-primary/90">
+            Korzystasz z alternatywnego źródła danych planu lekcji.
+          </p>
+          <p className="text-primary/70">
+            Plan został wczytany z „{selectedSourceName ?? selectedDataSource}”.
+            Dane mogą różnić się od głównego źródła. Jeśli to pomyłka, wybierz
+            ponownie Główny Plan lekcji w menu źródeł danych.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add a dedicated banner component highlighting when a non-standard timetable data source is active
- render the banner at the top of the timetable view so users notice the alternate source

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cba503db488323b4b84ef4c1653dac