### PR TITLE
Handle timetable routes without identifier

### DIFF
--- a/src/app/[...path]/page.tsx
+++ b/src/app/[...path]/page.tsx
@@ -10,7 +10,7 @@ import { TimetableController } from "@/components/timetable/TimetableController"
 import { Topbar } from "@/components/topbar/Topbar";
 import { DATA_SOURCE_COOKIE_NAME } from "@/lib/dataSource";
 import { cookies } from "next/headers";
-import { notFound } from "next/navigation";
+import { redirect } from "next/navigation";
 import { Fragment } from "react";
 import type { Metadata } from "next";
 import type { OptivumTimetable } from "@/types/optivum";
@@ -55,11 +55,16 @@ const TimetablePage = async ({
   const resolvedParams = await params;
   const [type, value] = resolvedParams.path ?? [];
 
+  const cookieStore = await cookies();
+  const lastVisited = cookieStore.get("lastVisited")?.value ?? "";
+
+  const validPattern = /^\/(class|teacher|room)\/\d+$/;
+  const redirectTo = validPattern.test(lastVisited) ? lastVisited : "/class/1";
+
   if (!isTimetableType(type) || !value) {
-    notFound();
+    redirect(redirectTo);
   }
 
-  const cookieStore = await cookies();
   const requestedDataSource = cookieStore.get(DATA_SOURCE_COOKIE_NAME)?.value;
 
   const timetable = await getOptivumTimetable(


### PR DESCRIPTION
## Summary
- redirect timetable routes without an identifier to the last visited timetable or the default /class/1
- reuse stored cookies to resolve the redirect target before loading timetable data

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d3c74a06048323944372fda0fdc0bf