### PR TITLE
Add printable timetable view with metadata

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -108,3 +108,35 @@
   background-color: rgb(var(--accent-table));
   color: #fafafa;
 }
+
+@media print {
+  :root,
+  .dark {
+    --background: 255 255 255;
+    --foreground: 255 255 255;
+    --accent: 255 255 255;
+    --accent-secondary: 255 255 255;
+    --primary: 0 0 0;
+    --lines: 209 213 219;
+  }
+
+  html {
+    background: #ffffff !important;
+  }
+
+  body {
+    background: #ffffff !important;
+    color: #000000 !important;
+    min-height: auto !important;
+  }
+
+  body *,
+  .dark * {
+    box-shadow: none !important;
+  }
+
+  a {
+    color: inherit !important;
+    text-decoration: none !important;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -46,14 +46,18 @@ export default function RootLayout({
       <body
         className={cn(
           poppins.className,
-          "flex h-screen antialiased bg-foreground md:bg-background",
+          "flex h-screen antialiased bg-foreground md:bg-background print:h-auto print:bg-white print:text-black",
         )}
       >
         <ThemeProvider attribute="class" disableTransitionOnChange>
-          <Toaster />
+          <div className="print:hidden">
+            <Toaster />
+          </div>
           <Sidebar />
           {children}
-          <SettingsPanel />
+          <div className="print:hidden">
+            <SettingsPanel />
+          </div>
         </ThemeProvider>
       </body>
     </html>

--- a/src/components/common/BottomBar.tsx
+++ b/src/components/common/BottomBar.tsx
@@ -50,15 +50,16 @@ export const BottomBar: FC<BottomBarProps> = ({ timetable }) => {
   };
 
   return (
-    <Drawer
-      /*
-        Testing needed: a known problem is scrolling the page after opening the bottom drawer on iOS
-        https://github.com/shadcn-ui/ui/issues/3943
-      */
-      onOpenChange={(isOpen) => {
-        if (isOpen) window.scrollTo(0, 0);
-      }}
-    >
+    <div className="print:hidden">
+      <Drawer
+        /*
+          Testing needed: a known problem is scrolling the page after opening the bottom drawer on iOS
+          https://github.com/shadcn-ui/ui/issues/3943
+        */
+        onOpenChange={(isOpen) => {
+          if (isOpen) window.scrollTo(0, 0);
+        }}
+      >
       <DrawerTrigger asChild>
         <div className="fixed bottom-0 flex h-20 w-full flex-col rounded-t-md border border-primary/10 bg-background dark:bg-foreground md:hidden">
           <div className="absolute left-0 right-0 top-1 mx-auto h-2 w-[100px] rounded-full bg-primary/10" />
@@ -101,6 +102,7 @@ export const BottomBar: FC<BottomBarProps> = ({ timetable }) => {
           <SidebarContent showTimetableDates />
         </div>
       </DrawerContent>
-    </Drawer>
+      </Drawer>
+    </div>
   );
 };

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -36,13 +36,13 @@ export const Sidebar: FC = () => {
 
   return (
     <Fragment>
-      <div className="border-lines dark:border-primary/10 bg-foreground h-screen w-full max-w-xs border-r max-xl:hidden max-md:hidden">
+      <div className="border-lines dark:border-primary/10 bg-foreground h-screen w-full max-w-xs border-r max-xl:hidden max-md:hidden print:hidden">
         <div className="mr-3 flex h-full w-full flex-col justify-between gap-y-16 overflow-x-hidden overflow-y-auto px-4 py-6">
           <SidebarContent />
         </div>
       </div>
 
-      <div className="max-md:hidden xl:hidden">
+      <div className="max-md:hidden xl:hidden print:hidden">
         <Sheet open={isSidebarOpen} onOpenChange={toggleSidebar}>
           <SheetTrigger asChild>
             <div className="border-lines dark:border-primary/10 bg-foreground flex h-screen w-24 cursor-pointer flex-col items-center gap-10 border-r px-4 py-6">

--- a/src/components/timetable/Timetable.tsx
+++ b/src/components/timetable/Timetable.tsx
@@ -98,10 +98,10 @@ export const Timetable: FC<TimetableProps> = ({ timetable }) => {
     <div
       className={cn(
         hasLessons ? "" : "flex-1",
-        "border-lines bg-foreground flex w-full flex-col transition-all max-md:mb-20 md:overflow-hidden md:rounded-md md:border",
+        "border-lines bg-foreground flex w-full flex-col transition-all max-md:mb-20 md:overflow-hidden md:rounded-md md:border print:mb-0 print:bg-white print:shadow-none print:rounded-none print:border print:border-black/10 print:overflow-visible",
       )}
     >
-      <div className="divide-lines border-lines bg-foreground sticky top-0 z-20 flex justify-between divide-x border-y md:hidden">
+      <div className="divide-lines border-lines bg-foreground sticky top-0 z-20 flex justify-between divide-x border-y md:hidden print:hidden">
         {dayNames.map((dayName) => (
           <TableHeaderMobileCell
             key={dayName}
@@ -113,7 +113,7 @@ export const Timetable: FC<TimetableProps> = ({ timetable }) => {
       </div>
 
       <div
-        className="flex-1 overflow-hidden md:hidden"
+        className="flex-1 overflow-hidden md:hidden print:hidden"
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
       >
@@ -163,9 +163,9 @@ export const Timetable: FC<TimetableProps> = ({ timetable }) => {
         </div>
       </div>
 
-      <div className="h-full w-full max-md:hidden md:overflow-auto">
+      <div className="h-full w-full max-md:hidden md:overflow-auto print:block print:overflow-visible">
         {hasLessons ? (
-          <table className="w-full">
+          <table className="w-full print:text-black">
             <thead className="max-md:hidden">
               <tr className="divide-lines border-lines divide-x border-b">
                 <th>

--- a/src/components/topbar/Buttons.tsx
+++ b/src/components/topbar/Buttons.tsx
@@ -1,12 +1,16 @@
 import { Button } from "@/components/ui/Button";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { useSettingsWithoutStore } from "@/stores/settings";
-import { MenuIcon, MoonIcon, SunMediumIcon } from "lucide-react";
+import { MenuIcon, MoonIcon, PrinterIcon, SunMediumIcon } from "lucide-react";
 import { useTheme } from "next-themes";
 import { FC, useCallback } from "react";
 import { useIsClient } from "usehooks-ts";
 
-export const TopbarButtons: FC = () => {
+interface TopbarButtonsProps {
+  onPrint: () => void;
+}
+
+export const TopbarButtons: FC<TopbarButtonsProps> = ({ onPrint }) => {
   const isClient = useIsClient();
 
   const { theme, setTheme, systemTheme } = useTheme();
@@ -21,6 +25,12 @@ export const TopbarButtons: FC = () => {
   }, [currentTheme, setTheme]);
 
   const buttons = [
+    {
+      icon: PrinterIcon,
+      href: null,
+      action: onPrint,
+      ariaLabel: "Drukuj plan lekcji",
+    },
     {
       icon: currentTheme === "dark" ? SunMediumIcon : MoonIcon,
       href: null,
@@ -40,7 +50,7 @@ export const TopbarButtons: FC = () => {
 
   if (!isClient)
     return (
-      <div className="inline-flex gap-x-2.5">
+      <div className="inline-flex gap-x-2.5 print:hidden">
         {Array.from({ length: buttons.length }).map((_, index) => (
           <Skeleton className="h-10 w-10" key={index} />
         ))}
@@ -48,18 +58,19 @@ export const TopbarButtons: FC = () => {
     );
 
   return (
-    <div className="inline-flex gap-2.5">
+    <div className="inline-flex gap-2.5 print:hidden">
       {buttons.map((button, index) => {
         const IconComponent = button.icon;
 
         return (
-            <Button
-              key={index}
-              aria-label={button.ariaLabel}
-              variant="icon"
-              size="icon"
-              onClick={button.action}
-            >
+          <Button
+            key={index}
+            aria-label={button.ariaLabel}
+            variant="icon"
+            size="icon"
+            onClick={button.action}
+            type="button"
+          >
             <IconComponent strokeWidth={2.5} className="size-4 sm:size-5" />
           </Button>
         );

--- a/src/components/topbar/Topbar.tsx
+++ b/src/components/topbar/Topbar.tsx
@@ -9,7 +9,7 @@ import { TRANSLATION_DICT } from "@/constants/translations";
 import { OptivumTimetable } from "@/types/optivum";
 import Image from "next/image";
 import Link from "next/link";
-import { FC, Fragment, useMemo } from "react";
+import { FC, Fragment, useCallback, useEffect, useMemo, useState } from "react";
 import { useIsClient } from "usehooks-ts";
 import { TopbarButtons } from "./Buttons";
 
@@ -19,6 +19,41 @@ interface TopbarProps {
 
 export const Topbar: FC<TopbarProps> = ({ timetable }) => {
   const isClient = useIsClient();
+  const [printTimestamp, setPrintTimestamp] = useState<string>("");
+
+  const updatePrintTimestamp = useCallback(() => {
+    const formatter = new Intl.DateTimeFormat("pl-PL", {
+      dateStyle: "long",
+      timeStyle: "short",
+    });
+
+    setPrintTimestamp(formatter.format(new Date()));
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    updatePrintTimestamp();
+
+    const handleBeforePrint = () => {
+      updatePrintTimestamp();
+    };
+
+    window.addEventListener("beforeprint", handleBeforePrint);
+
+    return () => {
+      window.removeEventListener("beforeprint", handleBeforePrint);
+    };
+  }, [updatePrintTimestamp]);
+
+  const handlePrint = useCallback(() => {
+    if (typeof window === "undefined") return;
+
+    updatePrintTimestamp();
+    requestAnimationFrame(() => {
+      window.print();
+    });
+  }, [updatePrintTimestamp]);
 
   const titleElement = useMemo(() => {
     if (timetable?.title) {
@@ -33,33 +68,56 @@ export const Topbar: FC<TopbarProps> = ({ timetable }) => {
     }
   }, [timetable]);
 
+  const printTitle = useMemo(() => {
+    if (!timetable?.title) return "Plan lekcji";
+
+    return `Plan lekcji ${TRANSLATION_DICT[timetable.type]} ${timetable.title}`;
+  }, [timetable]);
+
   return (
-    <div className="grid gap-2 max-md:px-3 max-md:pt-3">
-      <div className="flex w-full justify-between max-md:items-center">
-        <div className="flex gap-x-2 max-md:items-center">
-          <SchoolLink />
-          <div className="md:hidden">
-            <ShortLessonSwitcherCell />
+    <div className="grid gap-2 max-md:px-3 max-md:pt-3 print:gap-4">
+      <div className="grid gap-2 print:hidden">
+        <div className="flex w-full justify-between max-md:items-center">
+          <div className="flex gap-x-2 max-md:items-center">
+            <SchoolLink />
+            <div className="md:hidden">
+              <ShortLessonSwitcherCell />
+            </div>
           </div>
+          <TopbarButtons onPrint={handlePrint} />
         </div>
-        <TopbarButtons />
+        <div className="grid gap-1.5 max-md:hidden">
+          <div className="inline-flex items-center gap-x-4">
+            <h1 className="text-primary/90 xl:text-4.2xl max-w-2xl truncate text-3xl leading-tight font-semibold text-ellipsis">
+              {titleElement}
+            </h1>
+            {timetable?.title && isClient && (
+              <FavoriteStar
+                item={{
+                  name: timetable.title,
+                  value: timetable.id.substring(1),
+                  type: timetable.type,
+                }}
+              />
+            )}
+          </div>
+          <TimetableDates timetable={timetable} />
+        </div>
       </div>
-      <div className="grid gap-1.5 max-md:hidden">
-        <div className="inline-flex items-center gap-x-4">
-          <h1 className="text-primary/90 xl:text-4.2xl max-w-2xl truncate text-3xl leading-tight font-semibold text-ellipsis">
-            {titleElement}
-          </h1>
-          {timetable?.title && isClient && (
-            <FavoriteStar
-              item={{
-                name: timetable.title,
-                value: timetable.id.substring(1),
-                type: timetable.type,
-              }}
-            />
-          )}
+
+      <div className="hidden print:flex print:flex-col print:gap-2 print:border-b print:border-black/10 print:pb-4">
+        <p className="text-xs font-semibold uppercase tracking-wider text-black/70">
+          {timetable ? `Rozkład zajęć ${TRANSLATION_DICT[timetable.type]}` : "Plan lekcji"}
+        </p>
+        <h1 className="text-3xl font-semibold text-black">{printTitle}</h1>
+        <div className="text-sm text-black/80">
+          <TimetableDates timetable={timetable} />
         </div>
-        <TimetableDates timetable={timetable} />
+        {printTimestamp && (
+          <p className="text-sm font-medium text-black/70">
+            Data wydruku: <span className="font-semibold text-black">{printTimestamp}</span>
+          </p>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a print action in the top bar and expose timetable metadata on the print header
- apply print-specific styling and hide interactive UI so printouts use a clean light theme
- ensure the desktop timetable table is rendered for printed output

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d552680e64832386f4ae75fa2a3e91