### PR TITLE
Add printable timetable view and print button

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "next-themes": "^0.4.6",
     "react": "19.1.1",
     "react-dom": "19.1.1",
+    "react-to-print": "^3.1.1",
     "require-in-the-middle": "^7.5.2",
     "rrule": "^2.8.1",
     "sharp": "^0.34.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       react-dom:
         specifier: 19.1.1
         version: 19.1.1(react@19.1.1)
+      react-to-print:
+        specifier: ^3.1.1
+        version: 3.1.1(react@19.1.1)
       require-in-the-middle:
         specifier: ^7.5.2
         version: 7.5.2
@@ -2990,6 +2993,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-to-print@3.1.1:
+    resolution: {integrity: sha512-N0MUMhpl8nkGri13BjP7zusj3B/j+1eMOTt8N8PYuhBYGzA4PqTXqcihJ9cZw996dvhV6mBdwafIQCg3Ap5bKg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ~19
 
   react@19.1.1:
     resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
@@ -6478,6 +6486,10 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.13
+
+  react-to-print@3.1.1(react@19.1.1):
+    dependencies:
+      react: 19.1.1
 
   react@19.1.1: {}
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -136,6 +136,7 @@
     color: #111827 !important;
     font-size: 11px;
     line-height: 1.35;
+    font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     margin: 0;
   }
 
@@ -153,17 +154,22 @@
 
   .print-header {
     display: grid;
-    gap: 2px;
+    gap: 4px;
+    padding-bottom: 6px;
+    border-bottom: 1px solid #e5e7eb;
   }
 
   .print-header h1 {
     font-size: 1.25rem;
+    color: #0f172a;
   }
 
   .print-table {
     width: 100%;
     border-collapse: collapse;
     table-layout: fixed;
+    border-radius: 8px;
+    overflow: hidden;
   }
 
   .print-table th,
@@ -174,14 +180,29 @@
     word-break: break-word;
   }
 
-  .print-table th {
-    background-color: #f3f4f6;
+  .print-table thead th {
+    background-color: #e2e8f0;
     font-weight: 600;
+    color: #0f172a;
+  }
+
+  .print-table tbody tr:nth-child(odd) td {
+    background-color: #f8fafc;
+  }
+
+  .print-table tbody tr:nth-child(even) td {
+    background-color: #ffffff;
+  }
+
+  .print-table tbody td:first-child {
+    background-color: #e0e7ff;
+    font-weight: 600;
+    color: #1e3a8a;
   }
 
   .print-lesson {
     display: grid;
-    gap: 1px;
+    gap: 2px;
     margin-bottom: 4px;
   }
 
@@ -192,16 +213,17 @@
   .print-lesson__subject {
     font-weight: 600;
     font-size: 0.85rem;
+    color: #1f2937;
   }
 
   .print-lesson__meta {
-    color: #4b5563;
+    color: #475569;
     font-size: 0.7rem;
     line-height: 1.3;
   }
 
   .print-no-lessons {
     font-size: 0.95rem;
-    color: #374151;
+    color: #1f2937;
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -108,3 +108,57 @@
   background-color: rgb(var(--accent-table));
   color: #fafafa;
 }
+
+.print-container {
+  position: fixed;
+  top: -10000px;
+  left: -10000px;
+  opacity: 0;
+  pointer-events: none;
+  width: 100vw;
+}
+
+@media print {
+  :root,
+  .dark {
+    --background: 254 255 254 !important;
+    --foreground: 246 243 244 !important;
+    --accent: 254 255 254 !important;
+    --accent-secondary: 254 255 254 !important;
+    --accent-table: 239 9 51 !important;
+    --primary: 42 23 27 !important;
+    --lines: 208 201 203 !important;
+    color-scheme: light;
+  }
+
+  body {
+    background: #ffffff !important;
+    color: #111827 !important;
+  }
+
+  .print-container {
+    position: static;
+    opacity: 1;
+    pointer-events: auto;
+    width: auto;
+  }
+
+  .print-wrapper {
+    display: grid;
+    gap: 16px;
+  }
+
+  .print-header {
+    display: grid;
+    gap: 4px;
+  }
+
+  .print-table {
+    width: 100%;
+  }
+
+  .print-no-lessons {
+    font-size: 1rem;
+    color: #374151;
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -134,6 +134,9 @@
   body {
     background: #ffffff !important;
     color: #111827 !important;
+    font-size: 11px;
+    line-height: 1.35;
+    margin: 0;
   }
 
   .print-container {
@@ -145,20 +148,60 @@
 
   .print-wrapper {
     display: grid;
-    gap: 16px;
+    gap: 12px;
   }
 
   .print-header {
     display: grid;
-    gap: 4px;
+    gap: 2px;
+  }
+
+  .print-header h1 {
+    font-size: 1.25rem;
   }
 
   .print-table {
     width: 100%;
+    border-collapse: collapse;
+    table-layout: fixed;
+  }
+
+  .print-table th,
+  .print-table td {
+    border: 1px solid #d1d5db;
+    padding: 4px 6px;
+    vertical-align: top;
+    word-break: break-word;
+  }
+
+  .print-table th {
+    background-color: #f3f4f6;
+    font-weight: 600;
+  }
+
+  .print-lesson {
+    display: grid;
+    gap: 1px;
+    margin-bottom: 4px;
+  }
+
+  .print-lesson:last-child {
+    margin-bottom: 0;
+  }
+
+  .print-lesson__subject {
+    font-weight: 600;
+    font-size: 0.85rem;
+  }
+
+  .print-lesson__meta {
+    color: #4b5563;
+    font-size: 0.7rem;
+    line-height: 1.3;
   }
 
   .print-no-lessons {
-    font-size: 1rem;
+    font-size: 0.95rem;
     color: #374151;
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -175,7 +175,7 @@
   .print-table th,
   .print-table td {
     border: 1px solid #d1d5db;
-    padding: 4px 6px;
+    padding: 2px 4px;
     vertical-align: top;
     word-break: break-word;
   }
@@ -202,8 +202,8 @@
 
   .print-lesson {
     display: grid;
-    gap: 2px;
-    margin-bottom: 4px;
+    gap: 1px;
+    margin-bottom: 3px;
   }
 
   .print-lesson:last-child {

--- a/src/components/timetable/Timetable.tsx
+++ b/src/components/timetable/Timetable.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import { SHORT_HOURS } from "@/constants/settings";
+import { TRANSLATION_DICT } from "@/constants/translations";
 import { adjustShortenedLessons } from "@/lib/adjustShortenedLessons";
 import { cn } from "@/lib/utils";
 import { useSettingsStore, useSettingsWithoutStore } from "@/stores/settings";
+import { useTimetableStore } from "@/stores/timetable";
 import type { OptivumTimetable } from "@/types/optivum";
 import { CalendarX2 } from "lucide-react";
-import { FC, useMemo, useRef } from "react";
+import { FC, useEffect, useMemo, useRef, useState } from "react";
+import { useReactToPrint } from "react-to-print";
 import {
   ShortLessonSwitcherCell,
   TableHeaderCell,
@@ -37,6 +40,9 @@ export const Timetable: FC<TimetableProps> = ({ timetable }) => {
   );
   const setSelectedDayIndex = useSettingsWithoutStore(
     (state) => state.setSelectedDayIndex,
+  );
+  const setPrintTimetable = useTimetableStore(
+    (state) => state.setPrintTimetable,
   );
 
   const hours = useMemo(() => {
@@ -94,112 +100,268 @@ export const Timetable: FC<TimetableProps> = ({ timetable }) => {
     touchStartX.current = null;
   };
 
-  return (
-    <div
-      className={cn(
-        hasLessons ? "" : "flex-1",
-        "border-lines bg-foreground flex w-full flex-col transition-all max-md:mb-20 md:overflow-hidden md:rounded-md md:border",
-      )}
-    >
-      <div className="divide-lines border-lines bg-foreground sticky top-0 z-20 flex justify-between divide-x border-y md:hidden">
-        {dayNames.map((dayName) => (
-          <TableHeaderMobileCell
-            key={dayName}
-            dayName={dayName}
-            selectedDayIndex={selectedDayIndex}
-            setSelectedDayIndex={handleDayChange}
-          />
-        ))}
-      </div>
+  const printableRef = useRef<HTMLDivElement>(null);
 
+  const formatDate = (date: Date) =>
+    new Intl.DateTimeFormat("pl-PL", {
+      dateStyle: "long",
+      timeStyle: "short",
+    }).format(date);
+
+  const [printTimestamp, setPrintTimestamp] = useState(() => formatDate(new Date()));
+
+  const pageStyle = useMemo(
+    () =>
+      `@page { size: landscape; margin: 12mm; }
+      html, body {
+        width: 100%;
+        background: #ffffff !important;
+        color: #111827 !important;
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      }
+      table {
+        border-collapse: collapse;
+        width: 100%;
+      }
+      th, td {
+        border: 1px solid #d1d5db;
+        padding: 8px;
+        vertical-align: top;
+      }
+      th {
+        background-color: #f3f4f6;
+        font-weight: 600;
+      }
+      h1, h2, p {
+        margin: 0;
+        color: #111827 !important;
+      }
+      .print-lesson {
+        display: grid;
+        gap: 2px;
+        margin-bottom: 6px;
+      }
+      .print-lesson:last-child {
+        margin-bottom: 0;
+      }
+      .print-lesson__subject {
+        font-weight: 600;
+        font-size: 0.95rem;
+      }
+      .print-lesson__meta {
+        color: #4b5563;
+        font-size: 0.85rem;
+      }
+    `,
+    [],
+  );
+
+  const handlePrint = useReactToPrint({
+    content: () => printableRef.current,
+    pageStyle,
+    documentTitle: timetable.title
+      ? `Plan lekcji ${TRANSLATION_DICT[timetable.type]} ${timetable.title}`
+      : "Plan lekcji",
+    removeAfterPrint: false,
+    onBeforeGetContent: () =>
+      new Promise<void>((resolve) => {
+        setPrintTimestamp(formatDate(new Date()));
+        setTimeout(resolve, 0);
+      }),
+  });
+
+  useEffect(() => {
+    setPrintTimetable(handlePrint);
+    return () => setPrintTimetable(null);
+  }, [handlePrint, setPrintTimetable]);
+
+  return (
+    <>
       <div
-        className="flex-1 overflow-hidden md:hidden"
-        onTouchStart={handleTouchStart}
-        onTouchEnd={handleTouchEnd}
+        className={cn(
+          hasLessons ? "" : "flex-1",
+          "border-lines bg-foreground flex w-full flex-col transition-all max-md:mb-20 md:overflow-hidden md:rounded-md md:border",
+        )}
       >
+        <div className="divide-lines border-lines bg-foreground sticky top-0 z-20 flex justify-between divide-x border-y md:hidden">
+          {dayNames.map((dayName) => (
+            <TableHeaderMobileCell
+              key={dayName}
+              dayName={dayName}
+              selectedDayIndex={selectedDayIndex}
+              setSelectedDayIndex={handleDayChange}
+            />
+          ))}
+        </div>
+
         <div
-          className="flex h-full w-full transition-transform duration-300"
-          style={{ transform: `translateX(-${selectedDayIndex * 100}%)` }}
+          className="flex-1 overflow-hidden md:hidden"
+          onTouchStart={handleTouchStart}
+          onTouchEnd={handleTouchEnd}
         >
-          {dayNames.map((_, dayIndex) => {
-            const dayLessons = lessons[dayIndex] ?? [];
-            const dayHasLessons = dayLessons.some(
-              (hourLessons) => hourLessons.length > 0,
-            );
-            return (
-              <div
-                key={dayIndex}
-                className="flex h-full w-full flex-shrink-0 flex-col"
-              >
-                {dayHasLessons ? (
-                  <table className="w-full">
-                    <tbody>
-                      {visibleHours.map((hour, hourIndex) => (
-                        <tr
-                          key={hourIndex}
-                          className="border-lines odd:bg-accent/50 odd:dark:bg-background border-b"
-                        >
-                          <TableHourCell
-                            hour={hour}
-                            isCurrentDay={dayIndex === todayIndex}
-                          />
-                          <td className="py-3 last:border-0 max-md:px-2 md:px-4">
-                            {(lessons[dayIndex]?.[hourIndex] ?? []).map(
-                              (lessonItem, index) => (
-                                <LessonItem key={index} lesson={lessonItem} />
-                              ),
-                            )}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                ) : (
-                  <NoLessons description="Na ten dzień nie wprowadzono planu zajęć" />
-                )}
-              </div>
-            );
-          })}
+          <div
+            className="flex h-full w-full transition-transform duration-300"
+            style={{ transform: `translateX(-${selectedDayIndex * 100}%)` }}
+          >
+            {dayNames.map((_, dayIndex) => {
+              const dayLessons = lessons[dayIndex] ?? [];
+              const dayHasLessons = dayLessons.some(
+                (hourLessons) => hourLessons.length > 0,
+              );
+              return (
+                <div
+                  key={dayIndex}
+                  className="flex h-full w-full flex-shrink-0 flex-col"
+                >
+                  {dayHasLessons ? (
+                    <table className="w-full">
+                      <tbody>
+                        {visibleHours.map((hour, hourIndex) => (
+                          <tr
+                            key={hourIndex}
+                            className="border-lines odd:bg-accent/50 odd:dark:bg-background border-b"
+                          >
+                            <TableHourCell
+                              hour={hour}
+                              isCurrentDay={dayIndex === todayIndex}
+                            />
+                            <td className="py-3 last:border-0 max-md:px-2 md:px-4">
+                              {(lessons[dayIndex]?.[hourIndex] ?? []).map(
+                                (lessonItem, index) => (
+                                  <LessonItem key={index} lesson={lessonItem} />
+                                ),
+                              )}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  ) : (
+                    <NoLessons description="Na ten dzień nie wprowadzono planu zajęć" />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="h-full w-full max-md:hidden md:overflow-auto">
+          {hasLessons ? (
+            <table className="w-full">
+              <thead className="max-md:hidden">
+                <tr className="divide-lines border-lines divide-x border-b">
+                  <th>
+                    <ShortLessonSwitcherCell />
+                  </th>
+                  {dayNames.map((dayName) => (
+                    <TableHeaderCell key={dayName} dayName={dayName} />
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {visibleHours.map((hour, hourIndex) => (
+                  <tr
+                    key={hourIndex}
+                    className="divide-lines border-lines odd:bg-accent/50 odd:dark:bg-background border-b md:divide-x md:last:border-none"
+                  >
+                    <TableHourCell hour={hour} />
+                    {lessons.map((day, dayIndex) => (
+                      <TableLessonCell
+                        key={dayIndex}
+                        dayIndex={dayIndex}
+                        day={day}
+                        lessonIndex={hourIndex}
+                        selectedDayIndex={selectedDayIndex}
+                      />
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <NoLessons description="Na ten tydzień nie wprowadzono planu zajęć" />
+          )}
         </div>
       </div>
 
-      <div className="h-full w-full max-md:hidden md:overflow-auto">
-        {hasLessons ? (
-          <table className="w-full">
-            <thead className="max-md:hidden">
-              <tr className="divide-lines border-lines divide-x border-b">
-                <th>
-                  <ShortLessonSwitcherCell />
-                </th>
-                {dayNames.map((dayName) => (
-                  <TableHeaderCell key={dayName} dayName={dayName} />
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {visibleHours.map((hour, hourIndex) => (
-                <tr
-                  key={hourIndex}
-                  className="divide-lines border-lines odd:bg-accent/50 odd:dark:bg-background border-b md:divide-x md:last:border-none"
-                >
-                  <TableHourCell hour={hour} />
-                  {lessons.map((day, dayIndex) => (
-                    <TableLessonCell
-                      key={dayIndex}
-                      dayIndex={dayIndex}
-                      day={day}
-                      lessonIndex={hourIndex}
-                      selectedDayIndex={selectedDayIndex}
-                    />
+      <div ref={printableRef} className="print-container" aria-hidden="true">
+        <div className="print-wrapper">
+          <header className="print-header">
+            <h1>
+              Plan lekcji {TRANSLATION_DICT[timetable.type]} {timetable.title}
+            </h1>
+            <p>Data wydruku: {printTimestamp}</p>
+            {timetable.generatedDate && timetable.generatedDate !== "Invalid date" && (
+              <p>Plan wygenerowano: {timetable.generatedDate}</p>
+            )}
+            {timetable.validDate && (
+              <p>Obowiązuje od: {timetable.validDate}</p>
+            )}
+          </header>
+
+          {hasLessons ? (
+            <table className="print-table">
+              <thead>
+                <tr>
+                  <th>Godzina</th>
+                  {dayNames.map((dayName) => (
+                    <th key={dayName}>{dayName}</th>
                   ))}
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        ) : (
-          <NoLessons description="Na ten tydzień nie wprowadzono planu zajęć" />
-        )}
+              </thead>
+              <tbody>
+                {visibleHours.map((hour, hourIndex) => (
+                  <tr key={hourIndex}>
+                    <td>
+                      <div className="print-lesson">
+                        <span className="print-lesson__subject">{hour.number}. lekcja</span>
+                        <span className="print-lesson__meta">
+                          {hour.timeFrom} - {hour.timeTo}
+                        </span>
+                      </div>
+                    </td>
+                      {lessons.map((day, dayIndex) => (
+                        <td key={dayIndex}>
+                          {(hourIndex < day.length ? day[hourIndex] : []).map((lesson, lessonIndex) => {
+                          const lessonDetails = [
+                            lesson.teacher,
+                            lesson.className,
+                          ]
+                            .filter(Boolean)
+                            .join(" • ");
+
+                          return (
+                            <div className="print-lesson" key={lessonIndex}>
+                              <span className="print-lesson__subject">
+                                {lesson.subject}
+                                {lesson.groupName ? ` (${lesson.groupName})` : ""}
+                              </span>
+                              {lessonDetails && (
+                                <span className="print-lesson__meta">
+                                  {lessonDetails}
+                                </span>
+                              )}
+                              {lesson.room && (
+                                <span className="print-lesson__meta">
+                                  Sala {lesson.room}
+                                </span>
+                              )}
+                            </div>
+                          );
+                        })}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <p className="print-no-lessons">
+              Na ten tydzień nie wprowadzono planu zajęć.
+            </p>
+          )}
+        </div>
       </div>
-    </div>
+    </>
   );
 };

--- a/src/components/timetable/Timetable.tsx
+++ b/src/components/timetable/Timetable.tsx
@@ -306,6 +306,7 @@ export const Timetable: FC<TimetableProps> = ({ timetable }) => {
                           {hourLessons.map((lesson, lessonIndex) => {
                             const lessonDetails = [
                               lesson.teacher,
+                              lesson.room ? `Sala ${lesson.room}` : undefined,
                               lesson.className,
                             ]
                               .filter(Boolean)
@@ -319,9 +320,6 @@ export const Timetable: FC<TimetableProps> = ({ timetable }) => {
                                 </span>
                                 {lessonDetails && (
                                   <span className="print-lesson__meta">{lessonDetails}</span>
-                                )}
-                                {lesson.room && (
-                                  <span className="print-lesson__meta">Sala {lesson.room}</span>
                                 )}
                               </div>
                             );

--- a/src/components/timetable/Timetable.tsx
+++ b/src/components/timetable/Timetable.tsx
@@ -115,45 +115,63 @@ export const Timetable: FC<TimetableProps> = ({ timetable }) => {
 
   const pageStyle = useMemo(
     () =>
-      `@page { size: landscape; margin: 12mm; }
+      `@page { size: A4 landscape; margin: 10mm; }
       html, body {
         width: 100%;
+        margin: 0 !important;
         background: #ffffff !important;
         color: #111827 !important;
         font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      }
-      table {
-        border-collapse: collapse;
-        width: 100%;
-      }
-      th, td {
-        border: 1px solid #d1d5db;
-        padding: 8px;
-        vertical-align: top;
-      }
-      th {
-        background-color: #f3f4f6;
-        font-weight: 600;
+        font-size: 11px;
+        line-height: 1.35;
       }
       h1, h2, p {
         margin: 0;
         color: #111827 !important;
       }
+      .print-wrapper {
+        display: grid;
+        gap: 12px;
+      }
+      .print-header h1 {
+        font-size: 1.25rem;
+      }
+      .print-table {
+        border-collapse: collapse;
+        width: 100%;
+        table-layout: fixed;
+      }
+      .print-table th,
+      .print-table td {
+        border: 1px solid #d1d5db;
+        padding: 4px 6px;
+        vertical-align: top;
+        word-break: break-word;
+      }
+      .print-table th {
+        background-color: #f3f4f6;
+        font-weight: 600;
+      }
       .print-lesson {
         display: grid;
-        gap: 2px;
-        margin-bottom: 6px;
+        gap: 1px;
+        margin-bottom: 4px;
       }
       .print-lesson:last-child {
         margin-bottom: 0;
       }
       .print-lesson__subject {
         font-weight: 600;
-        font-size: 0.95rem;
+        font-size: 0.85rem;
       }
       .print-lesson__meta {
         color: #4b5563;
-        font-size: 0.85rem;
+        font-size: 0.7rem;
+        line-height: 1.3;
+      }
+      .print-no-lessons {
+        font-size: 0.95rem;
+        color: #374151;
       }
     `,
     [],

--- a/src/components/timetable/Timetable.tsx
+++ b/src/components/timetable/Timetable.tsx
@@ -164,6 +164,25 @@ export const Timetable: FC<TimetableProps> = ({ timetable }) => {
     return () => setPrintTimetable(null);
   }, [handlePrint, setPrintTimetable]);
 
+  useEffect(() => {
+    const handleKeydown = (event: KeyboardEvent) => {
+      if (event.repeat) return;
+
+      const isPrintShortcut = (event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "p";
+
+      if (!isPrintShortcut) return;
+
+      event.preventDefault();
+      handlePrint();
+    };
+
+    window.addEventListener("keydown", handleKeydown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeydown);
+    };
+  }, [handlePrint]);
+
   return (
     <>
       <div

--- a/src/components/topbar/Buttons.tsx
+++ b/src/components/topbar/Buttons.tsx
@@ -1,7 +1,11 @@
+"use client";
+
 import { Button } from "@/components/ui/Button";
 import { Skeleton } from "@/components/ui/Skeleton";
+import { useTimetableStore } from "@/stores/timetable";
 import { useSettingsWithoutStore } from "@/stores/settings";
-import { MenuIcon, MoonIcon, SunMediumIcon } from "lucide-react";
+import { MenuIcon, MoonIcon, PrinterIcon, SunMediumIcon } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { useTheme } from "next-themes";
 import { FC, useCallback } from "react";
 import { useIsClient } from "usehooks-ts";
@@ -12,6 +16,8 @@ export const TopbarButtons: FC = () => {
   const { theme, setTheme, systemTheme } = useTheme();
   const currentTheme = theme === "system" ? systemTheme : theme;
 
+  const printTimetable = useTimetableStore((state) => state.printTimetable);
+
   const toggleSettingsPanel = useSettingsWithoutStore(
     (state) => state.toggleSettingsPanel,
   );
@@ -20,11 +26,23 @@ export const TopbarButtons: FC = () => {
     setTheme(currentTheme === "light" ? "dark" : "light");
   }, [currentTheme, setTheme]);
 
-  const buttons = [
+  interface ButtonConfig {
+    icon: LucideIcon;
+    action?: () => void;
+    ariaLabel: string;
+    disabled?: boolean;
+  }
+
+  const buttons: ButtonConfig[] = [
+    {
+      icon: PrinterIcon,
+      action: printTimetable ? () => printTimetable() : undefined,
+      ariaLabel: "Drukuj plan lekcji",
+      disabled: !printTimetable,
+    },
     {
       icon: currentTheme === "dark" ? SunMediumIcon : MoonIcon,
-      href: null,
-      action: toggleTheme,
+      action: () => toggleTheme(),
       ariaLabel:
         currentTheme === "dark"
           ? "Przełącz na tryb jasny"
@@ -32,8 +50,7 @@ export const TopbarButtons: FC = () => {
     },
     {
       icon: MenuIcon,
-      href: null,
-      action: toggleSettingsPanel,
+      action: () => toggleSettingsPanel(),
       ariaLabel: "Otwórz panel ustawień",
     },
   ];
@@ -53,13 +70,14 @@ export const TopbarButtons: FC = () => {
         const IconComponent = button.icon;
 
         return (
-            <Button
-              key={index}
-              aria-label={button.ariaLabel}
-              variant="icon"
-              size="icon"
-              onClick={button.action}
-            >
+          <Button
+            key={index}
+            aria-label={button.ariaLabel}
+            variant="icon"
+            size="icon"
+            onClick={() => button.action?.()}
+            disabled={button.disabled}
+          >
             <IconComponent strokeWidth={2.5} className="size-4 sm:size-5" />
           </Button>
         );

--- a/src/stores/timetable.ts
+++ b/src/stores/timetable.ts
@@ -3,10 +3,14 @@ import { create } from "zustand";
 
 interface TimetableStore {
   timetable: OptivumTimetable | null;
+  printTimetable: (() => void) | null;
   setTimetable: (timetable: OptivumTimetable) => void;
+  setPrintTimetable: (printFn: (() => void) | null) => void;
 }
 
 export const useTimetableStore = create<TimetableStore>((set) => ({
   timetable: null,
+  printTimetable: null,
   setTimetable: (timetable) => set({ timetable }),
+  setPrintTimetable: (printFn) => set({ printTimetable: printFn }),
 }));


### PR DESCRIPTION
## Summary
- add a shared print handler using react-to-print and register it in the timetable store
- render a dedicated printable timetable layout with metadata and light theme styling
- expose a print button in the top bar alongside existing controls

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d63931c184832382553cde170ebad9